### PR TITLE
feat: add theme toggle with dark mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { ProjectProvider } from './context/ProjectContext';
 import { NotificationProvider } from './context/NotificationContext';
 import { useProject } from './context/ProjectContext';
+import { ThemeProvider } from './context/ThemeContext';
+import ThemeToggle from './components/ThemeToggle';
 import Home from './pages/Home';
 import ProjectPage from './pages/ProjectPage';
 import NotificationContainer from './components/NotificationContainer';
@@ -14,12 +16,19 @@ const AppContent: React.FC = () => {
 
 const App: React.FC = () => {
   return (
-    <NotificationProvider>
-      <ProjectProvider>
-        <AppContent />
-        <NotificationContainer />
-      </ProjectProvider>
-    </NotificationProvider>
+    <ThemeProvider>
+      <NotificationProvider>
+        <ProjectProvider>
+          <div className="min-h-screen relative">
+            <AppContent />
+            <NotificationContainer />
+            <div className="fixed top-4 right-4">
+              <ThemeToggle />
+            </div>
+          </div>
+        </ProjectProvider>
+      </NotificationProvider>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Sun, Moon } from 'lucide-react';
+import { useTheme } from '../context/ThemeContext';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="btn-secondary w-10 h-10 flex items-center justify-center rounded-lg"
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+    </button>
+  );
+};
+
+export default ThemeToggle;
+

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme') as Theme | null;
+      if (stored === 'dark' || stored === 'light') {
+        return stored;
+      }
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark';
+      }
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  const value: ThemeContextType = {
+    theme,
+    toggleTheme,
+  };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+

--- a/src/index.css
+++ b/src/index.css
@@ -8,43 +8,43 @@
   }
   
   body {
-    @apply bg-gray-50 text-gray-900;
+    @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
   }
 }
 
 @layer components {
   .btn-primary {
-    @apply bg-primary-600 hover:bg-primary-700 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200;
+    @apply bg-primary-600 hover:bg-primary-700 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 dark:bg-primary-500 dark:hover:bg-primary-400;
   }
-  
+
   .btn-secondary {
-    @apply bg-gray-200 hover:bg-gray-300 text-gray-800 font-medium py-2 px-4 rounded-lg transition-colors duration-200;
+    @apply bg-gray-200 hover:bg-gray-300 text-gray-800 font-medium py-2 px-4 rounded-lg transition-colors duration-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-100;
   }
-  
+
   .card {
-    @apply bg-white rounded-xl shadow-sm border border-gray-200 p-6;
+    @apply bg-white rounded-xl shadow-sm border border-gray-200 p-6 dark:bg-gray-800 dark:border-gray-700;
   }
-  
+
   .input-field {
-    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent;
+    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:ring-primary-400;
   }
 }
 
 /* React Flow custom styles */
 .react-flow__node {
-  @apply shadow-md border-2 border-gray-200;
+  @apply shadow-md border-2 border-gray-200 dark:border-gray-700 dark:bg-gray-800;
 }
 
 .react-flow__node.selected {
-  @apply border-primary-500 shadow-lg;
+  @apply border-primary-500 shadow-lg dark:border-primary-400;
 }
 
 .react-flow__handle {
-  @apply bg-primary-500 border-2 border-white;
+  @apply bg-primary-500 border-2 border-white dark:bg-primary-400 dark:border-gray-800;
 }
 
 .react-flow__edge-path {
-  @apply stroke-primary-500 stroke-2;
+  @apply stroke-primary-500 stroke-2 dark:stroke-primary-400;
 }
 
 /* Custom Animations */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode
- add dark variants for base elements and components
- introduce ThemeContext and ThemeToggle for persistent theme switching

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Type errors in components)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1ea264588323861b794573708a61